### PR TITLE
Fix crash on search with duplicate playlist keys

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/SearchScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/SearchScreen.kt
@@ -575,14 +575,19 @@ fun SearchResultsList(
                 }
 
                 // Add items for this section
-                items(itemsForSection, key = { item ->
-                    when (item) {
-                        is SearchResultItem.SongItem -> "song_${item.song.id}"
-                        is SearchResultItem.AlbumItem -> "album_${item.album.id}"
-                        is SearchResultItem.ArtistItem -> "artist_${item.artist.id}"
-                        is SearchResultItem.PlaylistItem -> "playlist_${item.playlist.id}"
+                items(
+                    count = itemsForSection.size,
+                    key = { index ->
+                        val item = itemsForSection[index]
+                        when (item) {
+                            is SearchResultItem.SongItem -> "song_${item.song.id}"
+                            is SearchResultItem.AlbumItem -> "album_${item.album.id}"
+                            is SearchResultItem.ArtistItem -> "artist_${item.artist.id}"
+                            is SearchResultItem.PlaylistItem -> "playlist_${item.playlist.id}_${index}"
+                        }
                     }
-                }) { item ->
+                ) { index ->
+                    val item = itemsForSection[index]
                     // Apply spacing for each item within the group
                     Box(modifier = Modifier.padding(bottom = 12.dp)) {
                         when (item) {


### PR DESCRIPTION
The app was crashing with an `IllegalArgumentException` when the search results contained playlists with duplicate IDs. This was because the `LazyColumn` key was generated using only the playlist ID, which was not guaranteed to be unique.

This change modifies the key generation for playlists in the search results to include the item's index, ensuring that the key is always unique.