### PR TITLE
Improve shuffle function when no songs are playing or displayed

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ To get a local copy up and running, follow these simple steps.
 
 1. Clone the repo
    ```sh
-   git clone https://github.com/your_username/PixelPlay.git
+   git clone https://github.com/theovilardo/PixelPlay.git
    ```
 2. Open the project in Android Studio.
 3. Let Gradle sync and download the required dependencies.

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibraryScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibraryScreen.kt
@@ -373,10 +373,7 @@ fun LibraryScreen(
                             onMainActionClick = {
                                 when (pagerState.currentPage) {
                                     3 -> showCreatePlaylistDialog = true
-                                    else -> {
-                                        playerViewModel.toggleShuffle()
-                                        playerViewModel.playPause()
-                                    }
+                                    else -> playerViewModel.shuffleAllSongs()
                                 }
                             },
                             iconRotation = iconRotation,

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
@@ -418,6 +418,15 @@ class PlayerViewModel @Inject constructor(
         }
     }
 
+    fun shuffleAllSongs() {
+        mediaController?.shuffleModeEnabled = true
+        val allSongs = _playerUiState.value.allSongs
+        if (allSongs.isNotEmpty()) {
+            val randomSong = allSongs.random()
+            playSongs(allSongs.toList(), randomSong, "All Songs (Shuffled)")
+        }
+    }
+
     private fun loadPersistedDailyMix() {
         viewModelScope.launch {
             // Combine the flow of persisted IDs with the flow of all songs


### PR DESCRIPTION
This change is focused on the library songs tab shuffle button. Previously when this button was touched the first song of the master list of songs would play, and there would be no queued songs afterwards. Now when the same button is clicked, a random song is chosen from the master song list and a queue of shuffled songs is added.