### PR TITLE
fix(animation): Synchronize player and navbar animations

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/MainActivity.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/MainActivity.kt
@@ -372,7 +372,7 @@ class MainActivity : ComponentActivity() {
                         label = "PlayerContentBottomRadius"
                     )
 
-                    val navBarHideFraction = if (showPlayerContentArea) playerContentExpansionFraction.pow(2) else 0f
+                    val navBarHideFraction = if (showPlayerContentArea) playerContentExpansionFraction else 0f
 
                     val actualShape = remember(playerContentActualBottomRadius, showPlayerContentArea, navBarStyle, navBarCornerRadius) {
                         val bottomRadius = if (navBarStyle == NavBarStyle.FULL_WIDTH) 0.dp else navBarCornerRadius.dp


### PR DESCRIPTION
The animation for the navigation bar sliding out of view was not synchronized with the mini-player's expansion animation. This was because the navbar's translation was calculated using the square of the expansion fraction (`.pow(2)`), creating a non-linear animation curve that caused it to overlap with the player during the transition.

This change removes the `.pow(2)` from the calculation, making the navbar's animation linear and directly proportional to the player's expansion. This ensures both elements move in tandem, maintaining a consistent separation and providing a smoother visual experience.