### PR TITLE
Add reset button to navbar corner radius slider

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/NavBarCornerRadiusScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/NavBarCornerRadiusScreen.kt
@@ -1,25 +1,32 @@
 package com.theveloper.pixelplay.presentation.screens
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.History
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Slider
 import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -32,14 +39,16 @@ import androidx.navigation.NavController
 import com.theveloper.pixelplay.presentation.viewmodel.SettingsViewModel
 import racra.compose.smooth_corner_rect_library.AbsoluteSmoothCornerShape
 
+const val DEFAULT_NAV_BAR_CORNER_RADIUS = 32f
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun NavBarCornerRadiusScreen(
-    navController: NavController,
-    settingsViewModel: SettingsViewModel = hiltViewModel()
+    navController: NavController, settingsViewModel: SettingsViewModel = hiltViewModel()
 ) {
     val uiState by settingsViewModel.uiState.collectAsState()
-    var sliderValue by remember { mutableStateOf(uiState.navBarCornerRadius.toFloat()) }
+    var sliderValue by remember { mutableFloatStateOf(uiState.navBarCornerRadius.toFloat()) }
+    var hasBeenAdjusted by remember { mutableStateOf(sliderValue != DEFAULT_NAV_BAR_CORNER_RADIUS) }
 
     LaunchedEffect(uiState.navBarCornerRadius) {
         sliderValue = uiState.navBarCornerRadius.toFloat()
@@ -47,19 +56,23 @@ fun NavBarCornerRadiusScreen(
 
     Scaffold(
         topBar = {
-            TopAppBar(
-                title = { Text("NavBar Corner Radius") },
-                actions = {
-                    TextButton(onClick = {
-                        settingsViewModel.setNavBarCornerRadius(sliderValue.toInt())
-                        navController.popBackStack()
-                    }) {
+            TopAppBar(title = { Text("NavBar Corner Radius") }, actions = {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    modifier = Modifier.padding(end = 8.dp)
+                ) {
+                    Button(
+                        onClick = {
+                            settingsViewModel.setNavBarCornerRadius(sliderValue.toInt())
+                            navController.popBackStack()
+                        },
+                    ) {
                         Text("Done")
                     }
                 }
-            )
-        }
-    ) { paddingValues ->
+            })
+        }) { paddingValues ->
         Box(
             modifier = Modifier
                 .fillMaxSize()
@@ -68,7 +81,7 @@ fun NavBarCornerRadiusScreen(
                 .padding(bottom = paddingValues.calculateBottomPadding())
         ) {
             Text(
-                text = "Match the black area's corners with your device's corners",
+                text = "Match the navbar shape's corners with your device's corners",
                 style = MaterialTheme.typography.headlineSmall,
                 textAlign = TextAlign.Center,
                 color = MaterialTheme.colorScheme.onBackground,
@@ -78,14 +91,49 @@ fun NavBarCornerRadiusScreen(
                     .padding(top = 32.dp)
             )
 
+
             Column(
-                modifier = Modifier
-                    .align(Alignment.BottomCenter),
+                modifier = Modifier.align(Alignment.BottomCenter),
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
+                if (hasBeenAdjusted) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 32.dp)
+                            .padding(bottom = 16.dp), horizontalArrangement = Arrangement.End
+                    ) {
+                        Button(
+                            onClick = {
+                                sliderValue = DEFAULT_NAV_BAR_CORNER_RADIUS
+                                hasBeenAdjusted = false
+                            }, colors = ButtonDefaults.buttonColors(
+                                containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                                contentColor = MaterialTheme.colorScheme.onSecondaryContainer
+                            )
+                        ) {
+                            Row(
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.spacedBy(6.dp)
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Rounded.History,
+                                    contentDescription = "Reset",
+                                )
+                                Text("Reset")
+                            }
+                        }
+                    }
+                }
+
                 Slider(
                     value = sliderValue,
-                    onValueChange = { sliderValue = it },
+                    onValueChange = {
+                        sliderValue = it
+                        if (!hasBeenAdjusted) {
+                            hasBeenAdjusted = true
+                        }
+                    },
                     valueRange = 0f..50f,
                     colors = SliderDefaults.colors(
                         thumbColor = MaterialTheme.colorScheme.primary,


### PR DESCRIPTION
This pull request updates the `NavBarCornerRadiusScreen` to improve usability by introducing a reset button for the navigation bar corner radius, refining the UI, and enhancing state management. The most significant changes are grouped below:

**New Feature: Reset Button**
* Added a "Reset" button that appears when the user adjusts the slider from its default value. Clicking it resets the slider to the default corner radius (`DEFAULT_NAV_BAR_CORNER_RADIUS`) and updates the UI accordingly. [[1]](diffhunk://#diff-bc791c1abd492905207d46ac7b7230ace99de605c1e642f1ddb9e1e40ab7032dR42-R75) [[2]](diffhunk://#diff-bc791c1abd492905207d46ac7b7230ace99de605c1e642f1ddb9e1e40ab7032dR94-R136)

**UI/UX Improvements**
* Changed the instructional text to clarify that the user should match the navbar shape's corners with their device's corners, improving clarity.
* Updated the layout of the top app bar and action buttons for better alignment and spacing, replacing the `TextButton` with a `Button` and using a `Row` for button arrangement.

**State Management Enhancements**
* Introduced `hasBeenAdjusted` state to track if the slider value has deviated from the default, controlling the visibility of the reset button. [[1]](diffhunk://#diff-bc791c1abd492905207d46ac7b7230ace99de605c1e642f1ddb9e1e40ab7032dR42-R75) [[2]](diffhunk://#diff-bc791c1abd492905207d46ac7b7230ace99de605c1e642f1ddb9e1e40ab7032dR94-R136)
* Switched from `mutableStateOf` to `mutableFloatStateOf` to fix warning,
<img width="435" height="984" alt="Screenshot 2025-09-15 234333" src="https://github.com/user-attachments/assets/763041ff-a8c8-4159-bda6-4491a87e6563" />
