### PR TITLE
Fix: Liked songs not playing as a playlist

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibraryScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibraryScreen.kt
@@ -373,6 +373,7 @@ fun LibraryScreen(
                             onMainActionClick = {
                                 when (pagerState.currentPage) {
                                     3 -> showCreatePlaylistDialog = true
+                                    4 -> playerViewModel.shuffleFavoriteSongs()
                                     else -> playerViewModel.shuffleAllSongs()
                                 }
                             },
@@ -776,7 +777,7 @@ fun LibraryFavoritesTab(
                         isCurrentSong = favoriteSongs.isNotEmpty() && stablePlayerState.currentSong == song,
                         isPlaying = isPlayingThisSong,
                         onMoreOptionsClick = { onMoreOptionsClick(song) },
-                        onClick = { playerViewModel.showAndPlaySong(song) }
+                        onClick = { playerViewModel.showAndPlaySong(song, favoriteSongs, "Liked Songs") }
                     )
                 }
             }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
@@ -433,6 +433,16 @@ class PlayerViewModel @Inject constructor(
         }
     }
 
+    fun shuffleFavoriteSongs() {
+        Log.d("ShuffleDebug", "shuffleFavoriteSongs called.")
+        mediaController?.shuffleModeEnabled = true
+        val favSongs = favoriteSongs.value
+        if (favSongs.isNotEmpty()) {
+            val shuffledList = favSongs.shuffled()
+            playSongs(shuffledList, shuffledList.first(), "Liked Songs (Shuffled)")
+        }
+    }
+
     private fun loadPersistedDailyMix() {
         viewModelScope.launch {
             // Combine the flow of persisted IDs with the flow of all songs


### PR DESCRIPTION
This commit resolves an issue where the 'Liked Songs' list in the library did not function as a self-contained playlist.

Previously, playing a song from the 'Liked' tab or using the shuffle button would incorrectly include all songs from the library in the playback queue.

This has been fixed by:
- Adding a `shuffleFavoriteSongs()` function to `PlayerViewModel` to specifically handle shuffling of the liked songs list.
- Updating `LibraryScreen.kt` to call the new shuffle function when the shuffle button is pressed on the 'Liked' tab.
- Modifying the song item's click handler in the 'Liked' tab to call `showAndPlaySong` with the `favoriteSongs` list, ensuring the playback queue is correctly limited to only liked songs.