### PR TITLE
Cache lyrics fetched from internet

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/repository/LyricsRepository.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/repository/LyricsRepository.kt
@@ -1,0 +1,11 @@
+package com.theveloper.pixelplay.data.repository
+
+import com.theveloper.pixelplay.data.model.Lyrics
+import com.theveloper.pixelplay.data.model.Song
+
+interface LyricsRepository {
+    suspend fun getLyrics(song: Song): Lyrics?
+    suspend fun fetchFromRemote(song: Song): Result<Pair<Lyrics, String>>
+    suspend fun updateLyrics(songId: Long, lyricsContent: String)
+    fun clearCache()
+}

--- a/app/src/main/java/com/theveloper/pixelplay/data/repository/LyricsRepositoryImpl.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/repository/LyricsRepositoryImpl.kt
@@ -1,0 +1,174 @@
+package com.theveloper.pixelplay.data.repository
+
+import android.content.Context
+import android.net.Uri
+import android.provider.OpenableColumns
+import android.util.LruCache
+import androidx.core.net.toUri
+import com.theveloper.pixelplay.data.database.MusicDao
+import com.theveloper.pixelplay.data.model.Lyrics
+import com.theveloper.pixelplay.data.model.Song
+import com.theveloper.pixelplay.data.network.lyrics.LrcLibApiService
+import com.theveloper.pixelplay.utils.LogUtils
+import com.theveloper.pixelplay.utils.LyricsUtils
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.jaudiotagger.audio.AudioFileIO
+import org.jaudiotagger.tag.FieldKey
+import java.io.File
+import java.io.FileOutputStream
+import javax.inject.Inject
+import javax.inject.Singleton
+
+private fun Lyrics.isValid(): Boolean = !synced.isNullOrEmpty() || !plain.isNullOrEmpty()
+
+@Singleton
+class LyricsRepositoryImpl @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val lrcLibApiService: LrcLibApiService,
+    private val musicDao: MusicDao
+) : LyricsRepository {
+
+    private val lyricsCache = LruCache<String, Lyrics>(100)
+
+    override suspend fun getLyrics(song: Song): Lyrics? = withContext(Dispatchers.IO) {
+        val cacheKey = generateCacheKey(song.id)
+        
+        lyricsCache.get(cacheKey)?.let { 
+            LogUtils.d(this@LyricsRepositoryImpl, "Cache hit for song: ${song.title}")
+            return@withContext it 
+        }
+
+        LogUtils.d(this@LyricsRepositoryImpl, "Cache miss for song: ${song.title}, loading from storage")
+        val lyrics = loadLyricsFromStorage(song)
+        lyrics?.let { 
+            lyricsCache.put(cacheKey, it)
+            LogUtils.d(this@LyricsRepositoryImpl, "Cached lyrics for song: ${song.title}")
+        }
+        
+        return@withContext lyrics
+    }
+
+    override suspend fun fetchFromRemote(song: Song): Result<Pair<Lyrics, String>> = withContext(Dispatchers.IO) {
+        try {
+            LogUtils.d(this@LyricsRepositoryImpl, "Fetching lyrics from remote for: ${song.title}")
+            val response = lrcLibApiService.getLyrics(
+                trackName = song.title,
+                artistName = song.artist,
+                albumName = song.album,
+                duration = (song.duration / 1000).toInt()
+            )
+            
+            if (response != null && (!response.syncedLyrics.isNullOrEmpty() || !response.plainLyrics.isNullOrEmpty())) {
+                val rawLyricsToSave = response.syncedLyrics ?: response.plainLyrics!!
+                
+                val parsedLyrics = LyricsUtils.parseLyrics(rawLyricsToSave).copy(areFromRemote = true)
+                if (!parsedLyrics.isValid()) {
+                    return@withContext Result.failure(LyricsException("Parsed lyrics are empty"))
+                }
+                
+                musicDao.updateLyrics(song.id.toLong(), rawLyricsToSave)
+                
+                val cacheKey = generateCacheKey(song.id)
+                lyricsCache.put(cacheKey, parsedLyrics)
+                LogUtils.d(this@LyricsRepositoryImpl, "Fetched and cached remote lyrics for: ${song.title}")
+                
+                Result.success(Pair(parsedLyrics, rawLyricsToSave))
+            } else {
+                LogUtils.d(this@LyricsRepositoryImpl, "No lyrics found remotely for: ${song.title}")
+                Result.failure(LyricsException("No lyrics found for this song"))
+            }
+        } catch (e: Exception) {
+            LogUtils.e(this@LyricsRepositoryImpl, e, "Error fetching lyrics from remote")
+            Result.failure(LyricsException("Failed to fetch lyrics from remote", e))
+        }
+    }
+
+    override suspend fun updateLyrics(songId: Long, lyricsContent: String): Unit = withContext(Dispatchers.IO) {
+        LogUtils.d(this@LyricsRepositoryImpl, "Updating lyrics for songId: $songId")
+        
+        val parsedLyrics = LyricsUtils.parseLyrics(lyricsContent)
+        if (!parsedLyrics.isValid()) {
+            LogUtils.w(this@LyricsRepositoryImpl, "Attempted to save empty lyrics for songId: $songId")
+            return@withContext
+        }
+        
+        musicDao.updateLyrics(songId, lyricsContent)
+        
+        val cacheKey = generateCacheKey(songId.toString())
+        lyricsCache.put(cacheKey, parsedLyrics)
+        LogUtils.d(this@LyricsRepositoryImpl, "Updated and cached lyrics for songId: $songId")
+    }
+
+    override fun clearCache() {
+        LogUtils.d(this, "Clearing lyrics cache")
+        lyricsCache.evictAll()
+    }
+
+    private suspend fun loadLyricsFromStorage(song: Song): Lyrics? = withContext(Dispatchers.IO) {
+        if (!song.lyrics.isNullOrBlank()) {
+            val parsedLyrics = LyricsUtils.parseLyrics(song.lyrics)
+            if (parsedLyrics.isValid()) {
+                return@withContext parsedLyrics.copy(areFromRemote = false)
+            }
+        }
+
+        return@withContext try {
+            val uri = song.contentUriString.toUri()
+            val tempFile = createTempFileFromUri(uri)
+            if (tempFile == null) {
+                LogUtils.w(this@LyricsRepositoryImpl, "Could not create temp file from URI: ${song.contentUriString}")
+                return@withContext null
+            }
+
+            try {
+                val audioFile = AudioFileIO.read(tempFile)
+                val tag = audioFile.tag
+                val lyricsField = tag?.getFirst(FieldKey.LYRICS)
+                
+                if (!lyricsField.isNullOrBlank()) {
+                    val parsedLyrics = LyricsUtils.parseLyrics(lyricsField)
+                    if (parsedLyrics.isValid()) {
+                        parsedLyrics.copy(areFromRemote = false)
+                    } else {
+                        null
+                    }
+                } else {
+                    null
+                }
+            } finally {
+                tempFile.delete()
+            }
+        } catch (e: Exception) {
+            LogUtils.e(this@LyricsRepositoryImpl, e, "Error reading lyrics from file metadata")
+            null
+        }
+    }
+
+    private fun generateCacheKey(songId: String): String = songId
+
+    private fun createTempFileFromUri(uri: Uri): File? {
+        return try {
+            context.contentResolver.openInputStream(uri)?.use { inputStream ->
+                val fileName = context.contentResolver.query(uri, null, null, null, null)?.use { cursor ->
+                    if (cursor.moveToFirst()) {
+                        val nameIndex = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+                        if (nameIndex >= 0) cursor.getString(nameIndex) else "temp_audio"
+                    } else "temp_audio"
+                } ?: "temp_audio"
+
+                val tempFile = File.createTempFile("lyrics_", "_$fileName", context.cacheDir)
+                FileOutputStream(tempFile).use { output ->
+                    inputStream.copyTo(output)
+                }
+                tempFile
+            }
+        } catch (e: Exception) {
+            LogUtils.e(this, e, "Error creating temp file from URI")
+            null
+        }
+    }
+}
+
+class LyricsException(message: String, cause: Throwable? = null) : Exception(message, cause)

--- a/app/src/main/java/com/theveloper/pixelplay/data/repository/MusicRepositoryImpl.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/repository/MusicRepositoryImpl.kt
@@ -38,7 +38,6 @@ import com.theveloper.pixelplay.data.database.toArtist
 import com.theveloper.pixelplay.data.database.toSong
 import com.theveloper.pixelplay.data.model.Lyrics
 import com.theveloper.pixelplay.data.model.SyncedLine
-import com.theveloper.pixelplay.data.network.lyrics.LrcLibApiService
 import com.theveloper.pixelplay.utils.LogUtils
 import com.theveloper.pixelplay.utils.LyricsUtils
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -54,8 +53,6 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 // import kotlinx.coroutines.sync.withLock // May not be needed if directoryScanMutex logic changes
 import java.io.File
-import org.jaudiotagger.audio.AudioFileIO
-import org.jaudiotagger.tag.FieldKey
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @Singleton
@@ -64,7 +61,7 @@ class MusicRepositoryImpl @Inject constructor(
     private val userPreferencesRepository: UserPreferencesRepository,
     private val searchHistoryDao: SearchHistoryDao,
     private val musicDao: MusicDao,
-    private val lrcLibApiService: LrcLibApiService
+    private val lyricsRepository: LyricsRepository
 ) : MusicRepository {
 
     private val directoryScanMutex = Mutex()
@@ -553,41 +550,7 @@ class MusicRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getLyrics(song: Song): Lyrics? {
-        // 1. Check if lyrics are already in the song object (from DB)
-        if (!song.lyrics.isNullOrBlank()) {
-            val parsedLyrics = LyricsUtils.parseLyrics(song.lyrics)
-            if (!parsedLyrics.synced.isNullOrEmpty() || !parsedLyrics.plain.isNullOrEmpty()) {
-                return parsedLyrics.copy(areFromRemote = false)
-            }
-        }
-
-        // 2. If not in DB, try to read from the file's metadata
-        return try {
-            val file = File(song.contentUriString)
-            if (!file.exists()) return null
-
-            val audioFile = AudioFileIO.read(file)
-            val tag = audioFile.tag
-            val lyricsFromFile = tag?.getFirst(FieldKey.LYRICS)
-
-            if (!lyricsFromFile.isNullOrBlank()) {
-                // 3. If found, update DB for caching
-                musicDao.updateLyrics(song.id.toLong(), lyricsFromFile)
-
-                // 4. Parse and return lyrics
-                val parsedLyrics = LyricsUtils.parseLyrics(lyricsFromFile)
-                if (!parsedLyrics.synced.isNullOrEmpty() || !parsedLyrics.plain.isNullOrEmpty()) {
-                    parsedLyrics.copy(areFromRemote = false)
-                } else {
-                    null
-                }
-            } else {
-                null
-            }
-        } catch (e: Exception) {
-            Log.e("MusicRepositoryImpl", "Error reading lyrics from file for song: ${song.title}", e)
-            null
-        }
+        return lyricsRepository.getLyrics(song)
     }
 
     /**
@@ -597,38 +560,11 @@ class MusicRepositoryImpl @Inject constructor(
      * @param song La canción para la cual se buscará la letra.
      * @return Un objeto Result que contiene el objeto Lyrics si se encontró, o un error.
      */
-    override suspend fun getLyricsFromRemote(song: Song): Result<Pair<Lyrics, String>> = withContext(Dispatchers.IO) {
-        try {
-            val response = lrcLibApiService.getLyrics(
-                trackName = song.title,
-                artistName = song.artist,
-                albumName = song.album,
-                duration = (song.duration / 1000).toInt()
-            )
-
-            if (response != null && (!response.syncedLyrics.isNullOrEmpty() || !response.plainLyrics.isNullOrEmpty())) {
-                // Prioritize synced for saving, but parse both for returning
-                val rawLyricsToSave = response.syncedLyrics ?: response.plainLyrics!!
-                musicDao.updateLyrics(song.id.toLong(), rawLyricsToSave)
-
-                // Use the centralized parser for the raw lyrics
-                val parsedLyrics = LyricsUtils.parseLyrics(rawLyricsToSave).copy(areFromRemote = true)
-
-                if (parsedLyrics.synced.isNullOrEmpty() && parsedLyrics.plain.isNullOrEmpty()) {
-                     return@withContext Result.failure(Exception("No lyrics found for this song."))
-                }
-
-                Result.success(Pair(parsedLyrics, rawLyricsToSave))
-            } else {
-                Result.failure(Exception("No lyrics found for this song."))
-            }
-        } catch (e: Exception) {
-            Log.e("MusicRepositoryImpl", "Error fetching lyrics from remote", e)
-            Result.failure(e)
-        }
+    override suspend fun getLyricsFromRemote(song: Song): Result<Pair<Lyrics, String>> {
+        return lyricsRepository.fetchFromRemote(song)
     }
 
     override suspend fun updateLyrics(songId: Long, lyrics: String) {
-        musicDao.updateLyrics(songId, lyrics)
+        lyricsRepository.updateLyrics(songId, lyrics)
     }
 }

--- a/app/src/main/java/com/theveloper/pixelplay/di/AppModule.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/di/AppModule.kt
@@ -134,14 +134,14 @@ object AppModule {
         userPreferencesRepository: UserPreferencesRepository,
         searchHistoryDao: SearchHistoryDao,
         musicDao: MusicDao, // Añadir MusicDao como parámetro
-        lrcLibApiService: LrcLibApiService
+        lyricsRepository: LyricsRepository
     ): MusicRepository {
         return MusicRepositoryImpl(
             context = context,
             userPreferencesRepository = userPreferencesRepository,
             searchHistoryDao = searchHistoryDao,
             musicDao = musicDao,
-            lrcLibApiService = lrcLibApiService // Pasar MusicDao
+            lyricsRepository = lyricsRepository
         )
     }
 

--- a/app/src/main/java/com/theveloper/pixelplay/di/AppModule.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/di/AppModule.kt
@@ -18,6 +18,8 @@ import com.theveloper.pixelplay.data.preferences.UserPreferencesRepository
 import com.theveloper.pixelplay.data.preferences.dataStore
 import com.theveloper.pixelplay.data.media.SongMetadataEditor
 import com.theveloper.pixelplay.data.network.lyrics.LrcLibApiService
+import com.theveloper.pixelplay.data.repository.LyricsRepository
+import com.theveloper.pixelplay.data.repository.LyricsRepositoryImpl
 import com.theveloper.pixelplay.data.repository.MusicRepository
 import com.theveloper.pixelplay.data.repository.MusicRepositoryImpl
 import com.theveloper.pixelplay.data.repository.TransitionRepository
@@ -109,6 +111,20 @@ object AppModule {
             .dispatcher(Dispatchers.Default) // Use CPU-bound dispatcher for decoding
             .allowHardware(true) // Re-enable hardware bitmaps for better performance
             .build()
+    }
+
+    @Provides
+    @Singleton
+    fun provideLyricsRepository(
+        @ApplicationContext context: Context,
+        lrcLibApiService: LrcLibApiService,
+        musicDao: MusicDao
+    ): LyricsRepository {
+        return LyricsRepositoryImpl(
+            context = context,
+            lrcLibApiService = lrcLibApiService,
+            musicDao = musicDao
+        )
     }
 
     @Provides


### PR DESCRIPTION
## Lyrics Cache Issue & Fix

Problem:
When you sync lyrics from the internet and then switch songs, the lyrics changes get lost. The app wasn't saving the fetched lyrics in memory, so every time you switched back to a song, it had to reload lyrics from scratch.

Fix:
 Created a lyrics cache that stores lyrics in memory using Android's LruCache. Now when you fetch lyrics from the internet, they get cached immediately. When you switch songs and come back, the lyrics are still there in the cache - no more lost changes.

  How it works:
  - First time: Load lyrics → cache them → show lyrics
  - Next time: Check cache → lyrics found → show instantly
  - Cache holds 100 songs worth of lyrics and automatically removes old ones when full

  The cache fixes the song-switching problem and makes lyrics load much faster.
  
  Note: I'm not well proficient in Android Development and this code is assisted by AI. This is Tested and worked fine.