### PR TITLE
feat: Implement marquee text and apply to all players

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/UnifiedPlayerSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/UnifiedPlayerSheet.kt
@@ -1348,28 +1348,29 @@ private fun MiniPlayerContentInternal(
             modifier = Modifier.weight(1f),
             verticalArrangement = Arrangement.Center
         ) {
-            Text(
-                text = song.title,
-                style = MaterialTheme.typography.titleSmall.copy(
-                    fontSize = 15.sp,
-                    fontWeight = FontWeight.SemiBold,
-                    letterSpacing = (-0.2).sp
-                ),
+            val titleStyle = MaterialTheme.typography.titleSmall.copy(
+                fontSize = 15.sp,
+                fontWeight = FontWeight.SemiBold,
+                letterSpacing = (-0.2).sp,
                 fontFamily = GoogleSansRounded,
-                color = LocalMaterialTheme.current.onPrimaryContainer,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis
+                color = LocalMaterialTheme.current.onPrimaryContainer
             )
-            Text(
-                text = song.artist,
-                style = MaterialTheme.typography.bodySmall.copy(
-                    fontSize = 13.sp,
-                    letterSpacing = 0.sp
-                ),
+            val artistStyle = MaterialTheme.typography.bodySmall.copy(
+                fontSize = 13.sp,
+                letterSpacing = 0.sp,
                 fontFamily = GoogleSansRounded,
-                color = LocalMaterialTheme.current.onPrimaryContainer.copy(alpha = 0.7f),
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis
+                color = LocalMaterialTheme.current.onPrimaryContainer.copy(alpha = 0.7f)
+            )
+
+            AutoScrollingText(
+                text = song.title,
+                style = titleStyle,
+                gradientEdgeColor = LocalMaterialTheme.current.primaryContainer
+            )
+            AutoScrollingText(
+                text = song.artist,
+                style = artistStyle,
+                gradientEdgeColor = LocalMaterialTheme.current.primaryContainer
             )
         }
         Spacer(modifier = Modifier.width(8.dp))


### PR DESCRIPTION
This commit introduces a sophisticated, reusable `AutoScrollingText` composable that provides a polished marquee effect for overflowing text, and applies it to both the full and mini player views.

The `AutoScrollingText` component includes several key refinements based on detailed feedback:

1.  **Animated Left Gradient Color:** To ensure the text is always visible before scrolling, the starting color of the left-side gradient's brush is animated from opaque (`gradientEdgeColor`) to transparent. This correctly creates the effect of the fade appearing only as the scroll begins.
2.  **Static Right Gradient:** The right-side gradient is rendered statically from the start to handle the initial text overflow.
3.  **Synchronized Animations:** The color animation is driven by a state change synchronized with the `initialDelayMillis` of the `basicMarquee` modifier, ensuring a seamless and polished user experience.
4.  **Adjusted Spacing:** The spacing between text repetitions in the marquee has been fine-tuned to `gradientWidth + 6.dp` as requested.

This component has been integrated into both the `PlayerSongInfo` (full player) and `MiniPlayerContentInternal` (mini-player) composables to handle long song titles and artist names, replacing the previous `TextOverflow.Ellipsis` truncation with a more elegant and user-friendly solution across the app.